### PR TITLE
Update license to CC0-1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About taxcalc
 
 Home: https://github.com/PSLmodels/Tax-Calculator
 
-Package license: CC-BY-1.0
+Package license: CC0-1.0
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/taxcalc-feedstock/blob/master/LICENSE.txt)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
    noarch: python
-   number: 0
+   number: 1
    script: "{{ PYTHON }} -m pip install . --no-deps -vv"
    entry_points:
     - tc = taxcalc.cli.tc:cli_tc_main
@@ -40,8 +40,8 @@ test:
 
 about:
   home: https://github.com/PSLmodels/Tax-Calculator
-  license: CC-BY-1.0
-  license_family: CC
+  license: CC0-1.0
+  license_family: PUBLIC-DOMAIN
   license_file: docs/about/license.md
   summary: 'open-source microsimulation model for static analysis of USA federal income and payroll taxes.'
   description: "Tax-Calculator is an open-source microsimulation model for static analysis of USA federal income and payroll taxes."


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR updates the license to `CC0-1.0` under `PUBLIC-DOMAIN`. @jdebacker pointed out that the license specification was incorrect based on comments he received for uploading Cost-of-Capital Calculator to `conda-forge`.
